### PR TITLE
chore: point playground links to kin-editor.vercel.app

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -17,7 +17,7 @@ export default function Hero() {
           <Button className='w-full sm:w-auto'>Documentation</Button>
         </Link>
         <a
-          href='https://editor.kinlang.dev'
+          href='https://kin-editor.vercel.app'
           target='_blank'
           rel='noopener noreferrer'
         >

--- a/src/components/NavbarInjector.tsx
+++ b/src/components/NavbarInjector.tsx
@@ -17,7 +17,7 @@ export default function NavbarInjector() {
     const docsText = isRwandan ? 'Ibisobanuro' : 'Documentation';
     const playgroundText = isRwandan ? 'Gerageza Kin' : 'Playground';
     const docsHref = isRwandan ? '/rw/docs' : '/docs';
-    const playgroundHref = 'https://editor.kinlang.dev';
+    const playgroundHref = 'https://kin-editor.vercel.app';
 
     const isDocsActive = asPath.includes('/docs');
 

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -29,7 +29,7 @@ export default function HomePage() {
               <Button className='w-full sm:w-auto'>Documentation</Button>
             </Link>
             <a
-              href='https://editor.kinlang.dev'
+              href='https://kin-editor.vercel.app'
               target='_blank'
               rel='noopener noreferrer'
             >

--- a/src/pages/rw/index.mdx
+++ b/src/pages/rw/index.mdx
@@ -29,7 +29,7 @@ export default function HomePage() {
               <Button className='w-full sm:w-auto'>Ibisobanuro</Button>
             </Link>
             <a
-              href='https://editor.kinlang.dev'
+              href='https://kin-editor.vercel.app'
               target='_blank'
               rel='noopener noreferrer'
             >

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -96,7 +96,7 @@ const config = {
       const docsText = isRwandan ? 'Ibisobanuro' : 'Documentation';
       const playgroundText = isRwandan ? 'Gerageza Kin' : 'Playground';
       const docsHref = isRwandan ? '/rw/docs' : '/docs';
-      const playgroundHref = 'https://editor.kinlang.dev';
+      const playgroundHref = 'https://kin-editor.vercel.app';
 
       const isDocsActive = asPath.includes('/docs');
 


### PR DESCRIPTION
## Summary
- Replace outdated `https://editor.kinlang.dev` playground/editor links with `https://kin-editor.vercel.app` on landing pages, navbar, and theme config

## Notes
- Link updates only; no release