### PR TITLE
fix: remove invalid public property from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,0 @@
-{
-  "public": true
-}


### PR DESCRIPTION
## Summary
- Delete `vercel.json` which only contained `{"public": true}`
- That property is no longer valid in the Vercel schema and was failing deployment builds with: *should NOT have additional property `public`*

## Notes
- No release; deploy-config fix only